### PR TITLE
opt-in only: remove ActiveRecord::Base 'include Hashid::Rails'. Model…

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,15 @@ Or install it yourself as:
 
 ## Usage
 
+Model classes must opt-in to hashids by including the mixin module:
+
+```
+class Model < ActiveRecord::Base
+  include Hashid::Rails
+  ...
+end
+```
+
 Just use `Model#find` passing in the hashid instead of the model id:
 
 ```ruby

--- a/lib/hashid/rails.rb
+++ b/lib/hashid/rails.rb
@@ -61,4 +61,5 @@ module Hashid
 
 end
 
-ActiveRecord::Base.send :include, Hashid::Rails
+# opt-in only
+#ActiveRecord::Base.send :include, Hashid::Rails

--- a/spec/hashid/rails_spec.rb
+++ b/spec/hashid/rails_spec.rb
@@ -69,6 +69,7 @@ describe Hashid::Rails do
 end
 
 class Model < ActiveRecord::Base
+  include Hashid::Rails
 
   def self.columns_hash
     {id: ActiveRecord::ConnectionAdapters::Column.new('id', nil, 'integer', 'integer')}


### PR DESCRIPTION
…s must explicitly include.
